### PR TITLE
Add Emaps base structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Boavizta](./src/lib/boavizta/README.md)
 - [CCF](./src/lib/ccf/README.md)
 - [CO2.JS](./src/lib/co2js/README.md)
+- [Electricity Maps](./src/lib/electricity-maps/README.md)
 - [Teads AWS](./src/lib/teads-aws/README.md)
 - [Teads TDP Curve](./src/lib/teads-curve/README.md)
 - [Watt Time](./src/lib/watt-time/README.md)

--- a/src/lib/electricity-maps/index.ts
+++ b/src/lib/electricity-maps/index.ts
@@ -1,0 +1,38 @@
+import * as dotenv from 'dotenv';
+
+import {ERRORS} from '../../util/errors';
+import {buildErrorMessage} from '../../util/helpers';
+
+import {ModelParams} from '../../types/common';
+import {ModelPluginInterface} from '../../interfaces';
+
+const {AuthorizationError} = ERRORS;
+
+
+const BASE_URL = 'https://api.electricitymap.org/v3';
+
+export class ElectricityMapsModel implements ModelPluginInterface {
+    authorizationHeader: string = '';
+    errorBuilder = buildErrorMessage(ElectricityMapsModel);
+    async configure(): Promise<ModelPluginInterface> {
+        this.initAuth();
+        return this;
+    }
+    async execute(inputs: ModelParams[]): Promise<ModelParams[]> {
+        const outputs: ModelParams[] = [];
+        return outputs;
+    }
+    initAuth() {
+        dotenv.config();
+        const token = process.env.EMAPS_TOKEN;
+        if (!token) {
+            throw new AuthorizationError(
+                this.errorBuilder({
+                    message: 'Missing token',
+                    scope: 'authorization',
+                })
+            );
+        }
+        this.authorizationHeader = `auth-token: ${token}`;
+    }
+}

--- a/src/lib/electricity-maps/index.ts
+++ b/src/lib/electricity-maps/index.ts
@@ -24,7 +24,9 @@ export class ElectricityMapsModel implements ModelPluginInterface {
     async execute(inputs: ModelParams[]): Promise<ModelParams[]> {
             return inputs.map((model_param)=>{
                 let unit = 'gCO2eq/kWh';
+                let power_consumption = model_param.power_consumption;
                 if (!model_param.power_consumption) {
+                    power_consumption = 1;
                     unit = 'gCO2eq';
                 }
                 const start = dayjs(model_param.timestamp);
@@ -53,7 +55,7 @@ export class ElectricityMapsModel implements ModelPluginInterface {
                 ));
                 return {
                     ...model_param,
-                    carbon_intensity: total_carbon_intensity,
+                    carbon_intensity: total_carbon_intensity * power_consumption,
                     unit: unit
                 }
             });

--- a/src/lib/electricity-maps/index.ts
+++ b/src/lib/electricity-maps/index.ts
@@ -83,7 +83,7 @@ export class ElectricityMapsModel implements ModelPluginInterface {
         if (end.diff(start, 'days') > 10) {
             throw InputValidationError(
                 this.errorBuilder({
-                    message: 'The maximum duration is 10 days for the Emaps API.',
+                    message: 'The maximum duration is 10 days for the Electricity Maps API.',
                     scope: 'input',
                 })
             )

--- a/src/lib/electricity-maps/index.ts
+++ b/src/lib/electricity-maps/index.ts
@@ -74,6 +74,14 @@ export class ElectricityMapsModel implements ModelPluginInterface {
         this.authorizationHeader = `auth-token: ${token}`;
     }
     private async get_carbon_intensity(longitude: number, latitude: number, start: dayjs.Dayjs, end: dayjs.Dayjs): Promise<KeyValuePair[]> {
+        if (isNaN(latitude) || isNaN(longitude)) {
+            throw InputValidationError(
+                this.errorBuilder({
+                    message: 'Longitude and Latitude are required for the Electricity Maps API.',
+                    scope: 'input',
+                })
+            )
+        }
         const parameters = {
             lon: longitude,
             lat: latitude,

--- a/src/lib/electricity-maps/index.ts
+++ b/src/lib/electricity-maps/index.ts
@@ -1,26 +1,28 @@
+/* eslint-disable prettier/prettier */
 import * as dotenv from 'dotenv';
+import axios from 'axios';
 
 import {ERRORS} from '../../util/errors';
 import {buildErrorMessage} from '../../util/helpers';
 
-import {ModelParams} from '../../types/common';
+import {KeyValuePair, ModelParams} from '../../types/common';
 import {ModelPluginInterface} from '../../interfaces';
 
-const {AuthorizationError} = ERRORS;
 
+const {AuthorizationError, APIRequestError} = ERRORS;
 
 const BASE_URL = 'https://api.electricitymap.org/v3';
 
 export class ElectricityMapsModel implements ModelPluginInterface {
-    authorizationHeader: string = '';
+    authorizationHeader = '';
     errorBuilder = buildErrorMessage(ElectricityMapsModel);
     async configure(): Promise<ModelPluginInterface> {
-        this.initAuth();
-        return this;
+            this.initAuth();
+            return this;
     }
     async execute(inputs: ModelParams[]): Promise<ModelParams[]> {
-        const outputs: ModelParams[] = [];
-        return outputs;
+            const outputs: ModelParams[] = [];
+            return outputs;
     }
     initAuth() {
         dotenv.config();
@@ -34,5 +36,31 @@ export class ElectricityMapsModel implements ModelPluginInterface {
             );
         }
         this.authorizationHeader = `auth-token: ${token}`;
+    }
+    private async get_carbon_intensity(zone_key?: string, latitude?: number, longitude?: number): Promise<KeyValuePair> {
+        // TODO handle parameters
+        const url = `${BASE_URL}/carbon-intensity/latest`;
+        const response = await axios.get(
+            url,
+            {
+                headers: {
+                    'auth-token': this.authorizationHeader,
+                },
+            }
+        )
+        if (response.status !== 200) {
+            throw new APIRequestError(
+                this.errorBuilder({
+                  message: `Error fetching data from WattTime API: ${JSON.stringify(
+                    response.status
+                  )}`,
+                })
+              );
+        }
+        const data = response.data;
+        return {
+            key: 'carbon_intensity',
+            value: data.carbonIntensity,
+        };
     }
 }

--- a/src/lib/electricity-maps/index.ts
+++ b/src/lib/electricity-maps/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable prettier/prettier */
 import * as dotenv from 'dotenv';
+import * as dayjs from 'dayjs';
 import axios from 'axios';
 
 import {ERRORS} from '../../util/errors';
@@ -9,7 +10,7 @@ import {KeyValuePair, ModelParams} from '../../types/common';
 import {ModelPluginInterface} from '../../interfaces';
 
 
-const {AuthorizationError, APIRequestError} = ERRORS;
+const {AuthorizationError, InputValidationError, APIRequestError} = ERRORS;
 
 const BASE_URL = 'https://api.electricitymap.org/v3';
 
@@ -22,7 +23,40 @@ export class ElectricityMapsModel implements ModelPluginInterface {
     }
     async execute(inputs: ModelParams[]): Promise<ModelParams[]> {
             const outputs: ModelParams[] = [];
-            return outputs;
+            return inputs.map((model_param)=>{
+                let unit = 'gCO2eq/kWh';
+                if (!model_param.power_consumption) {
+                    unit = 'gCO2eq';
+                }
+                const start = dayjs(model_param.timestamp);
+                const end = start.add(model_param.duration, 'second');
+                const carbon_intensities = this.get_carbon_intensity(model_param.longitude, model_param.latitude, start, end);
+                const hours = Math.floor(model_param.duration / 3600);
+                const blocs = [...Array(hours).keys()]
+                // Calculate for each full hour the ratio of the hour that is in the bloc
+                const hourly_ratios = blocs.map((hour) => {
+                    // this is the first hourly bloc, the ratio is the time between the start and the next hour.
+                    if (hour === 0) {
+                        return start.add(1, 'hour').startOf('hour').diff(start, 'second') / 3600;
+                    }
+                    // this is the last hourly bloc, the ratio is the time between the start of the hour and the end.
+                    if (hour === hours - 1) {
+                        return end.diff(start.add(hour, 'hour').startOf('hour'), 'second') / 3600;
+                    }
+                    return 1;
+                });
+                let total_carbon_intensity = 0;
+                carbon_intensities.forEach(
+                    (carbon_intensity, index)=>{
+                        total_carbon_intensity += carbon_intensity.value * hourly_ratios[index];
+                    }
+                )
+                return {
+                    ...model_param,
+                    carbon_intensity: total_carbon_intensity,
+                    unit: unit
+                }
+            });
     }
     initAuth() {
         dotenv.config();
@@ -37,30 +71,48 @@ export class ElectricityMapsModel implements ModelPluginInterface {
         }
         this.authorizationHeader = `auth-token: ${token}`;
     }
-    private async get_carbon_intensity(zone_key?: string, latitude?: number, longitude?: number): Promise<KeyValuePair> {
-        // TODO handle parameters
-        const url = `${BASE_URL}/carbon-intensity/latest`;
-        const response = await axios.get(
+    private get_carbon_intensity(longitude: number, latitude: number, start: dayjs.Dayjs, end: dayjs.Dayjs): KeyValuePair[] {
+        const parameters = {
+            lon: longitude,
+            lat: latitude,
+            start: start,
+            end: end
+        }
+        if (end.diff(start, 'days') > 10) {
+            throw InputValidationError(
+                this.errorBuilder({
+                    message: 'The maximum duration is 10 days for the Emaps API.',
+                    scope: 'input',
+                })
+            )
+        }
+        const url = `${BASE_URL}/carbon-intensity/past-range`;
+        const response = axios.get(
             url,
             {
+                params: parameters,
                 headers: {
                     'auth-token': this.authorizationHeader,
-                },
+                }
             }
         )
-        if (response.status !== 200) {
-            throw new APIRequestError(
-                this.errorBuilder({
-                  message: `Error fetching data from WattTime API: ${JSON.stringify(
-                    response.status
-                  )}`,
+        response.then(
+            (response)=>{
+                if (response.status !== 200) {
+                    throw new APIRequestError(
+                        this.errorBuilder({
+                            message: `Error: ${JSON.stringify(response.status)}`,
+                        })
+                    );
+                }
+                const data: KeyValuePair[] = response.data;
+                return data.map((carbon_intensity_data) => {
+                    return {
+                        datetime: carbon_intensity_data.datetime,
+                        value: carbon_intensity_data.carbonIntensity,
+                    }
                 })
-              );
-        }
-        const data = response.data;
-        return {
-            key: 'carbon_intensity',
-            value: data.carbonIntensity,
-        };
+            }
+        )
     }
 }


### PR DESCRIPTION
For now working in our fork until we are ready to submit it to GSF.

Adding an Emaps model to the Impact framework unofficial models. The goal of the model is for an event starting at `timestamp` and lasting a certain `duration` located in `lat, long` calculate the total carbon emission (if the power consumption is supplied) or the carbon intensity.

The model expects an input like this:
```
[{
    // Impact Framework params:
    timestamp: datetime
    duration: number
    // Added by us
    longitude: float,
    lattitude: float
   (power_consumption: float) optional
}]
```

The readme and other descriptions will be added at a later stage.